### PR TITLE
Fix issue: TypeError: Not enough arguments to EventTarget.removeEventListener

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -26,7 +26,7 @@ const TextareaAutosize = React.createClass({
 
   componentWillUnmount() {
     if (this.props.onResize) {
-      this.refs.textarea.getDOMNode().removeEventListener(RESIZED);
+      this.refs.textarea.getDOMNode().removeEventListener(RESIZED, this.props.onResize);
     }
     this.dispatchEvent(DESTROY);
   },


### PR DESCRIPTION
When I use this on Firefox, I got the issue "TypeError: Not enough arguments to EventTarget.removeEventListener.". This caused by the missing 2nd parameter in line 29.
![screenshot from 2015-09-19 13 07 32](https://cloud.githubusercontent.com/assets/4471670/9974866/6d23f190-5ecf-11e5-83bf-1ea6cc01e81e.png)
