### PR TITLE
FIX: Ref issue & Compatibility with React 15.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autosize-textarea",
-  "version": "0.4.0",
+  "version": "0.3.3",
   "description": "replacement for built-in textarea which auto resizes itself",
   "main": "index.js",
   "scripts": {
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "autosize": "^3.0.15",
-    "eslint-config-buildo": "github:buildo/eslint-config",
     "tcomb-react": "^0.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autosize-textarea",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "replacement for built-in textarea which auto resizes itself",
   "main": "index.js",
   "scripts": {
@@ -51,9 +51,9 @@
     "karma-webpack": "^1.7.0",
     "lodash": "^3.10.1",
     "mocha": "^2.4.5",
-    "react": "^0.14",
+    "react": "^15.4",
     "react-addons-test-utils": "^0.14.8 || ^15.0.0",
-    "react-dom": "^0.14",
+    "react-dom": "^15.4",
     "react-readme-generator": "0.0.1",
     "require-dir": "^0.3.0",
     "webpack": "^1.12.12",
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "autosize": "^3.0.15",
+    "eslint-config-buildo": "github:buildo/eslint-config",
     "tcomb-react": "^0.9.3"
   }
 }

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -22,22 +22,16 @@ export default class TextareaAutosize extends React.Component {
     rows: 1
   };
 
-  getTextareaDOMNode = () => (
-    this.refs.textarea.nodeType === 1 ?
-      this.refs.textarea :
-      ReactDOM.findDOMNode(this.refs.textarea)
-  );
-
   componentDidMount() {
-    autosize(this.getTextareaDOMNode());
+    autosize(this.textarea);
     if (this.props.onResize) {
-      this.getTextareaDOMNode().addEventListener(RESIZED, this.props.onResize);
+      this.textarea.addEventListener(RESIZED, this.props.onResize);
     }
   }
 
   componentWillUnmount() {
     if (this.props.onResize) {
-      this.getTextareaDOMNode().removeEventListener(RESIZED, this.props.onResize);
+      this.textarea.removeEventListener(RESIZED, this.props.onResize);
     }
     this.dispatchEvent(DESTROY);
   }
@@ -45,7 +39,7 @@ export default class TextareaAutosize extends React.Component {
   dispatchEvent = (EVENT_TYPE, defer) => {
     const event = document.createEvent('Event');
     event.initEvent(EVENT_TYPE, true, false);
-    const dispatch = () => this.getTextareaDOMNode().dispatchEvent(event);
+    const dispatch = () => this.textarea.dispatchEvent(event);
     if (defer) {
       setTimeout(dispatch);
     } else {
@@ -58,7 +52,7 @@ export default class TextareaAutosize extends React.Component {
   render() {
     const { children, onResize, ...props } = this.props;  // eslint-disable-line no-unused-vars
     return (
-      <textarea {...props} ref='textarea'>
+      <textarea {...props} ref={ref => this.textarea = ref}>
         {children}
       </textarea>
     );

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import autosize from 'autosize';
 import { t, props } from 'tcomb-react';
 

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -51,7 +51,7 @@ export default class TextareaAutosize extends React.Component {
   render() {
     const { children, onResize, ...props } = this.props;  // eslint-disable-line no-unused-vars
     return (
-      <textarea {...props} ref={ref => this.textarea = ref}>
+      <textarea {...props} ref={(ref) => { this.textarea = ref; }}>
         {children}
       </textarea>
     );


### PR DESCRIPTION
Fixed Compatbility issue with 15.4, switched from text refs to callback refs. And purged **getTextareaDOMNode**