### PR TITLE
#25: Max Rows (closes #25)

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -33,11 +33,12 @@ class Example extends React.Component {
           placeholder='minimun height is 3 rows'
         />
 
-        <h2>Maximum height is 5 "rows"</h2>
+        <h2>Maximum height is 3 "rows"</h2>
         <TextareaAutosize
-          maxRows={5}
+          maxRows={3}
           style={this.textareaStyle}
           placeholder='maximum height is 5 rows'
+          defaultValue={'this\nis\na\nlong\ninitial\ntext'}
         />
 
         <h2>Prefilled with initial value</h2>

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -5,6 +5,7 @@ import TextareaAutosize from '../src/TextareaAutosize';
 class Example extends React.Component {
 
   textareaStyle = {
+    width: 300,
     padding: '10px 8px',
     border: '1px solid rgba(39, 41, 43, .15)',
     borderRadius: 4,
@@ -27,9 +28,16 @@ class Example extends React.Component {
 
         <h2>Minimum height is 3 "rows"</h2>
         <TextareaAutosize
-          rows='3'
+          rows={3}
           style={this.textareaStyle}
           placeholder='minimun height is 3 rows'
+        />
+
+        <h2>Maximum height is 5 "rows"</h2>
+        <TextareaAutosize
+          maxRows={5}
+          style={this.textareaStyle}
+          placeholder='maximum height is 5 rows'
         />
 
         <h2>Prefilled with initial value</h2>

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -31,8 +31,19 @@ export default class TextareaAutosize extends React.Component {
   }
 
   componentDidMount() {
+    const { value, defaultValue, onResize } = this.props;
+
     autosize(this.textarea);
-    if (this.props.onResize) {
+
+    if (this.hasReachedMaxRows(value || defaultValue)) {
+      this.updateMaxHeight(value || defaultValue);
+
+      // this trick is needed to force "autosize" to activate the scrollbar
+      this.dispatchEvent(DESTROY);
+      setTimeout(() => autosize(this.textarea));
+    }
+
+    if (onResize) {
       this.textarea.addEventListener(RESIZED, this.props.onResize);
     }
   }

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -22,8 +22,7 @@ export const Props = {
 export default class TextareaAutosize extends React.Component {
 
   static defaultProps = {
-    rows: 1,
-    maxRows: 5
+    rows: 1
   };
 
   state = {

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -7,19 +7,28 @@ const UPDATE = 'autosize:update',
   RESIZED = 'autosize:resized';
 
 export const Props = {
+  rows: t.maybe(t.Integer),
+  maxRows: t.maybe(t.Integer),
   onResize: t.maybe(t.Function)
 };
 
 /** A light replacement for built-in textarea component
  * which automaticaly adjusts its height to match the content
  * @param onResize - called whenever the textarea resizes
+ * @param rows - minimum number of visible rows
+ * @param maxRows - maximum number of visible rows
  */
 @props(Props, { strict: false })
 export default class TextareaAutosize extends React.Component {
 
   static defaultProps = {
-    rows: 1
+    rows: 1,
+    maxRows: 5
   };
+
+  state = {
+    maxHeight: null
+  }
 
   componentDidMount() {
     autosize(this.textarea);
@@ -44,10 +53,52 @@ export default class TextareaAutosize extends React.Component {
 
   getValue = ({ valueLink, value }) => valueLink ? valueLink.value : value;
 
+  onChange = e => {
+    const {
+      props: { maxRows, onChange },
+      state: { maxHeight }
+    } = this;
+
+    const numberOfRows = e.target.value.split('\n').length;
+
+    if (!maxHeight && numberOfRows >= maxRows) {
+      const computedStyle = window.getComputedStyle(this.textarea);
+
+      const paddingTop = parseFloat(computedStyle.getPropertyValue('padding-top'), 10);
+      const paddingBottom = parseFloat(computedStyle.getPropertyValue('padding-top'), 10);
+      const verticalPadding = (paddingTop || 0) + (paddingBottom || 0);
+
+      const borderTopWidth = parseInt(computedStyle.getPropertyValue('border-top-width'), 10);
+      const borderBottomWidth = parseInt(computedStyle.getPropertyValue('border-bottom-width'), 10);
+      const verticalBorderWidth = (borderTopWidth || 0) + (borderBottomWidth || 0);
+
+      this.setState({
+        maxHeight: this.textarea.offsetHeight - verticalPadding - verticalBorderWidth
+      });
+    } else if (maxHeight && numberOfRows < maxRows) {
+      this.setState({ maxHeight: null });
+    }
+
+    onChange && onChange(e);
+  }
+
+  getLocals = () => {
+    const {
+      props: { onResize, maxRows, onChange, style, ...props }, // eslint-disable-line no-unused-vars
+      state: { maxHeight }
+    } = this;
+
+    return {
+      ...props,
+      style: maxHeight ? { ...style, maxHeight } : style,
+      onChange: this.onChange
+    };
+  }
+
   render() {
-    const { children, onResize, ...props } = this.props;  // eslint-disable-line no-unused-vars
+    const { children, ...locals } = this.getLocals();
     return (
-      <textarea {...props} ref={(ref) => { this.textarea = ref; }}>
+      <textarea {...locals} ref={(ref) => { this.textarea = ref; }}>
         {children}
       </textarea>
     );


### PR DESCRIPTION
Issue #25

## Test Plan

### tests performed
I tested with the new "maxRows" example (maxRows = 3):
- start with empty textarea
  - add 4 rows
  - `maxHeight` is set to the equivalent of 3 rows
- start with textarea prefilled with manu rows
  - `maxHeight` is set to the equivalent of 3 rows

NOTE: in this GIF you may notice that you actually see 4 rows at once. This is normal and due to the `padding` which is not considered for scroll-overflow.

[![https://gyazo.com/312f730dad33e3aa4f2cf1679de105a5](https://i.gyazo.com/312f730dad33e3aa4f2cf1679de105a5.gif)](https://gyazo.com/312f730dad33e3aa4f2cf1679de105a5)
### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
