### PR TITLE
#27: Getting a lot of Null is not an object in production (closes #27)

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,7 +46,7 @@ module.exports = function (config) {
         loaders: [
           {
             test: /\.jsx?$/,
-            loader: 'babel?stage=0&loose',
+            loader: 'babel',
             include: [paths.SRC, paths.TEST],
             exclude: /node_modules/
           }

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -35,15 +35,11 @@ export default class TextareaAutosize extends React.Component {
     this.dispatchEvent(DESTROY);
   }
 
-  dispatchEvent = (EVENT_TYPE, defer) => {
+  dispatchEvent = (EVENT_TYPE) => {
     const event = document.createEvent('Event');
     event.initEvent(EVENT_TYPE, true, false);
-    const dispatch = () => this.textarea.dispatchEvent(event);
-    if (defer) {
-      setTimeout(dispatch);
-    } else {
-      dispatch();
-    }
+
+    this.textarea.dispatchEvent(event);
   };
 
   getValue = ({ valueLink, value }) => valueLink ? valueLink.value : value;
@@ -57,9 +53,9 @@ export default class TextareaAutosize extends React.Component {
     );
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.getValue(nextProps) !== this.getValue(this.props)) {
-      this.dispatchEvent(UPDATE, true);
+  componentDidUpdate(prevProps) {
+    if (this.getValue(prevProps) !== this.getValue(this.props)) {
+      this.dispatchEvent(UPDATE);
     }
   }
 


### PR DESCRIPTION
Issue #27

## Test Plan

### tests performed
- in the examples, change a textarea's value with a `setTimeout` after 1 second to trigger a manul update
  - textarea resized correctly!

[![https://gyazo.com/76d55f05cc1a40878066eccc471b97eb](https://i.gyazo.com/76d55f05cc1a40878066eccc471b97eb.gif)](https://gyazo.com/76d55f05cc1a40878066eccc471b97eb)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
