### PR TITLE
callback handler for ref DOM node

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ In addition to `minHeight`, you can force `TextareaAutosize` to have a minimum n
 <TextareaAutosize rows={3} /> // minimun height is three rows
 ```
 
+#### Refs to DOM nodes
+
+```jsx
+
+class Form extends Component {
+  componentDidMount() {
+    this.textarea.focus()
+  }
+
+  render() {
+    return (
+      <TextareaAutosize innerRef={(ref) => { this.textarea = ref }} />
+    )
+  }
+}
+```
+
 ## Browser Compatibility
 | Chrome        | Firefox       | IE    | Safari | Android |
 | ------------- | ------------- | ----- | ------ | ------- |

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -118,10 +118,15 @@ export default class TextareaAutosize extends React.Component {
     };
   }
 
+  onInnerRef = (ref) => {
+    if (this.props.innerRef) { this.props.innerRef(ref);}
+    this.textarea = ref;
+  }
+
   render() {
     const { children, ...locals } = this.getLocals();
     return (
-      <textarea {...locals} ref={(ref) => { this.textarea = ref; }}>
+      <textarea {...locals} ref={this.onInnerRef}>
         {children}
       </textarea>
     );


### PR DESCRIPTION
To do something with this we need the ref of the DOM node.
#### Refs to DOM nodes

```jsx

class Form extends Component {
  componentDidMount() {
    this.textarea.focus()
  }

  render() {
    return (
      <TextareaAutosize innerRef={(ref) => { this.textarea = ref }} />
    )
  }
}