### PR TITLE
#50: Max rows not working with text without breakline char (closes #50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "dependencies": {
     "autosize": "^3.0.15",
+    "line-height": "^0.3.1",
     "prop-types": "^15.5.6"
   }
 }

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -69,7 +69,6 @@ export default class TextareaAutosize extends React.Component {
   }
 
   onChange = e => {
-    this.updateMaxHeight(e.target.value);
     this.props.onChange && this.props.onChange(e);
   }
 

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -22,14 +22,14 @@ export default class TextareaAutosize extends React.Component {
   };
 
   state = {
-    maxHeight: null
+    lineHeight: null
   }
 
   componentDidMount() {
     const { onResize, maxRows } = this.props;
 
     if (typeof maxRows === 'number') {
-      this.updateMaxHeight();
+      this.updateLineHeight();
 
       // this trick is needed to force "autosize" to activate the scrollbar
       setTimeout(() => autosize(this.textarea));
@@ -58,14 +58,10 @@ export default class TextareaAutosize extends React.Component {
 
   getValue = ({ valueLink, value }) => valueLink ? valueLink.value : value;
 
-  updateMaxHeight = () => {
-    const { maxRows } = this.props;
-
+  updateLineHeight = () => {
     this.setState({
-      maxHeight: getLineHeight(this.textarea) * maxRows
+      lineHeight: getLineHeight(this.textarea)
     });
-
-    return true;
   }
 
   onChange = e => {
@@ -85,9 +81,11 @@ export default class TextareaAutosize extends React.Component {
   getLocals = () => {
     const {
       props: { onResize, maxRows, onChange, style, innerRef, ...props }, // eslint-disable-line no-unused-vars
-      state: { maxHeight },
+      state: { lineHeight },
       saveDOMNodeRef
     } = this;
+
+    const maxHeight = maxRows && lineHeight ? lineHeight * maxRows : null;
 
     return {
       ...props,

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -92,7 +92,7 @@ export default class TextareaAutosize extends React.Component {
     return {
       ...props,
       saveDOMNodeRef,
-      style: maxHeight ? { ...style, maxHeight, padding: 0 } : style,
+      style: maxHeight ? { ...style, maxHeight } : style,
       onChange: this.onChange
     };
   }

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -58,14 +58,6 @@ export default class TextareaAutosize extends React.Component {
 
   getValue = ({ valueLink, value }) => valueLink ? valueLink.value : value;
 
-  hasReachedMaxRows = (value) => {
-    const { maxRows } = this.props;
-
-    const numberOfRows = (value || '').split('\n').length;
-
-    return numberOfRows >= parseInt(maxRows);
-  }
-
   updateMaxHeight = () => {
     const { maxRows } = this.props;
 


### PR DESCRIPTION
Closes #50

## Test Plan

### tests performed
- maxRows=3 and current examples -> it works
- maxRows=3 and broken example from issue -> it works
- maxRows=5 and broken example from issue then, after 3 seconds change it 3 -> it works and it updates

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
