### PR TITLE
#54: `this.dispatchEvent(UPDATE)` called too often (closes #54)

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -65,6 +65,7 @@ export default class TextareaAutosize extends React.Component {
   }
 
   onChange = e => {
+    this.currentValue = e.target.value;
     this.props.onChange && this.props.onChange(e);
   }
 
@@ -104,8 +105,8 @@ export default class TextareaAutosize extends React.Component {
     );
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.getValue(prevProps) !== this.getValue(this.props)) {
+  componentDidUpdate() {
+    if (this.getValue(this.props) !== this.currentValue) {
       this.dispatchEvent(UPDATE);
     }
   }


### PR DESCRIPTION
Closes #54

## Test Plan

### tests performed
tested in Chrome, Safari 10 and IE11:
- every example still works correctly
- improve first example to programmatically change `value` to a long one after some seconds
  - it updates correctly

[![https://gyazo.com/b124280ad130733c0bc0193062966197](https://i.gyazo.com/b124280ad130733c0bc0193062966197.gif)](https://gyazo.com/b124280ad130733c0bc0193062966197)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
