### PR TITLE
#56: JSX element type 'TextareaAutosize' is not a constructor function for JSX elements. (closes #56)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,0 @@
-import * as React from 'react';
-
-export interface TextareaAutosizeProps extends React.HTMLAttributes<HTMLTextAreaElement> {
-  maxRows?: number,
-  onResize?: (e: React.SyntheticEvent<Event>) => void,
-  innerRef?: (textarea: HTMLTextAreaElement) => void
-}
-
-export default class TextareaAutosize extends React.Component<TextareaAutosizeProps, void> {}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-autosize-textarea",
   "version": "0.4.6",
   "description": "replacement for built-in textarea which auto resizes itself",
-  "main": "index.js",
+  "main": "lib",
   "scripts": {
     "test": "npm run build && ./node_modules/karma/bin/karma start",
     "build": "rm -rf lib && mkdir lib && babel src -d lib",
@@ -39,10 +39,9 @@
     "lib",
     "src",
     "examples",
-    "index.js",
-    "index.d.ts"
+    "react-autosize-textarea.d.ts"
   ],
-  "typings": "./index.d.ts",
+  "typings": "react-autosize-textarea.d.ts",
   "homepage": "https://github.com/buildo/react-autosize-textarea",
   "devDependencies": {
     "@types/react": "^15.0.24",

--- a/react-autosize-textarea.d.ts
+++ b/react-autosize-textarea.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="react" />
+
+import * as React from 'react';
+
+export interface TextareaAutosizeProps extends React.HTMLAttributes<HTMLTextAreaElement> {
+  onResize?: (e: React.SyntheticEvent<Event>) => void,
+  // rows is already typed in `React.HTMLAttributes<HTMLTextAreaElement>`
+  maxRows?: number,
+  innerRef?: (textarea: HTMLTextAreaElement) => void
+}
+
+declare const TextareaAutosize: React.ComponentClass<TextareaAutosizeProps>;
+export default TextareaAutosize

--- a/test/tests/TextareaAutosize-test.js
+++ b/test/tests/TextareaAutosize-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import expect from 'expect';
-import TextareaAutosize from '../../index';
+import TextareaAutosize from '../../lib';
 
 
 const renderTextarea = () => {


### PR DESCRIPTION
Closes #56

## Test Plan

### tests performed
tested with Typescript 2.4.1 and 2.3.4 -> typing works as expected
