### PR TITLE
IE11 getComputedStyle prevention

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "autosize": "^3.0.15",
+    "autosize": "^4.0.0",
     "line-height": "^0.3.1",
     "prop-types": "^15.5.6"
   }

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -32,9 +32,19 @@ export default class TextareaAutosize extends React.Component {
       this.updateLineHeight();
 
       // this trick is needed to force "autosize" to activate the scrollbar
-      setTimeout(() => autosize(this.textarea));
+      setTimeout(() => {
+        try {
+          autosize(this.textarea);
+        } catch (e) {
+          console.error('Autosize Error:', e);
+        }
+      });
     } else {
-      autosize(this.textarea);
+      try {
+        autosize(this.textarea);
+      } catch (e) {
+        console.error('Autosize Error:', e);
+      }
     }
 
     if (onResize) {


### PR DESCRIPTION
There's this weird bug in IE11 and below, if there is a React Component with ReactAutosizeTextarea, the component will no longer trigger componentDidMount because  `window.getComputedStyle(ta, null);` throws an access denied.

Should be fixed in `autosize` repo, but until then, added autosize in a try catch to prevent the error from disrupting the whole application 

Also updated package.json to autosize v.4 (thought that will fix it), apparently not.