### PR TITLE
Add type declaration pointer to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "replacement for built-in textarea which auto resizes itself",
   "main": "lib",
+  "typings": "lib",
   "scripts": {
     "test": "jest",
     "build": "rm -rf lib && mkdir lib && tsc",


### PR DESCRIPTION
Closes #82 

Fixes error of TypeScript not seeing the packaged type declaration files.
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Attached is the error seen when using TS 2.6.2 and TS 2.5.3.
<img width="451" alt="screen shot 2017-12-04 at 6 36 33 pm" src="https://user-images.githubusercontent.com/1646307/33582283-778c5990-d922-11e7-94ac-d53a1c163f12.png">

Thanks again for all your work!