### PR TITLE
#71: Wrong initial height when using StyledComponents (closes #71)

### DIFF
--- a/examples/Examples.md
+++ b/examples/Examples.md
@@ -17,6 +17,24 @@
 />
 ```
 
+#### Maximum height
+
+using `maxRows`
+```js
+<TextareaAutosize
+  maxRows={3}
+  defaultValue={'this\nis\na\nlong\ninitial\ntext'}
+/>
+```
+
+using `maxHeight`
+```js
+<TextareaAutosize
+  style={{ maxHeight: 100, boxSizing: 'border-box' }}
+  defaultValue={'this\nis\na\nlong\ninitial\ntext'}
+/>
+```
+
 #### Prefilled
 
 ```js

--- a/src/TextareaAutosize.tsx
+++ b/src/TextareaAutosize.tsx
@@ -63,12 +63,14 @@ export default class TextareaAutosize extends React.Component<TextareaAutosize.P
 
     if (typeof maxRows === 'number') {
       this.updateLineHeight();
-
-      // this trick is needed to force "autosize" to activate the scrollbar
-      setTimeout(() => autosize(this.textarea));
-    } else {
-      autosize(this.textarea);
     }
+
+    /*
+      the defer is needed to:
+        - force "autosize" to activate the scrollbar when this.props.maxRows is passed
+        - support StyledComponents (see #71)
+    */
+    setTimeout(() => autosize(this.textarea));
 
     if (onResize) {
       this.textarea.addEventListener(RESIZED, onResize as any);


### PR DESCRIPTION
Closes #71

## Test Plan

### tests performed
npm start -> examples work fine

refer to #69 to see the original PR from @hitmands where he pointed out that the defer fixed his issue with `StyledComponents`

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
