### PR TITLE
Update to use React.forwardRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/jest": "21.1.8",
     "@types/node": "8.0.54",
     "@types/prop-types": "15.5.2",
-    "@types/react": "16.0.30",
+    "@types/react": "^16.8.3",
     "babel-loader": "^7.1.2",
     "babel-preset-buildo": "^0.1.1",
     "css-loader": "^0.28.5",

--- a/src/TextareaAutosize.tsx
+++ b/src/TextareaAutosize.tsx
@@ -1,157 +1,161 @@
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
-import * as autosize from 'autosize';
-import * as _getLineHeight from 'line-height';
+import * as React from "react";
+import * as PropTypes from "prop-types";
+import * as autosize from "autosize";
+import * as _getLineHeight from "line-height";
 
 const getLineHeight = _getLineHeight as (element: HTMLElement) => number | null;
 
 export namespace TextareaAutosize {
   export type RequiredProps = Pick<
     React.HTMLProps<HTMLTextAreaElement>,
-    Exclude<keyof React.HTMLProps<HTMLTextAreaElement>, 'ref'>
+    Exclude<keyof React.HTMLProps<HTMLTextAreaElement>, "ref">
   > & {
     /** Called whenever the textarea resizes */
-    onResize?: (e: Event) => void,
+    onResize?: (e: Event) => void;
     /** Minimum number of visible rows */
-    rows?: React.HTMLProps<HTMLTextAreaElement>['rows']
+    rows?: React.HTMLProps<HTMLTextAreaElement>["rows"];
     /** Maximum number of visible rows */
-    maxRows?: number,
-    /** Called with the ref to the DOM node */
-    innerRef?: (textarea: HTMLTextAreaElement) => void
+    maxRows?: number;
     /** Initialize `autosize` asynchronously.
      * Enable it if you are using StyledComponents
      * This is forced to true when `maxRows` is set.
      */
-    async?: boolean
-  }
+    async?: boolean;
+    forwardedRef?: React.RefObject<HTMLTextAreaElement>;
+  };
   export type DefaultProps = {
-    rows: number
-    async: boolean
-  }
+    rows: number;
+    async: boolean;
+  };
   export type Props = RequiredProps & Partial<DefaultProps>;
   export type State = {
-    lineHeight: number | null
-  }
+    lineHeight: number | null;
+  };
 }
 
-const RESIZED = 'autosize:resized';
+const RESIZED = "autosize:resized";
 
 /**
  * A light replacement for built-in textarea component
  * which automaticaly adjusts its height to match the content
  */
-export class TextareaAutosize extends React.Component<TextareaAutosize.Props, TextareaAutosize.State> {
-
+class TextareaAutosizeInner extends React.Component<
+  TextareaAutosize.Props,
+  TextareaAutosize.State
+> {
   static defaultProps: TextareaAutosize.DefaultProps = {
     rows: 1,
     async: false
   };
 
-  static propTypes: { [key in keyof TextareaAutosize.Props]: PropTypes.Requireable<any> } = {
+  static propTypes: {
+    [key in keyof TextareaAutosize.Props]: PropTypes.Requireable<any>
+  } = {
     rows: PropTypes.number,
     maxRows: PropTypes.number,
     onResize: PropTypes.func,
-    innerRef: PropTypes.func,
+    forwardedRef: PropTypes.shape({
+      current: PropTypes.instanceOf(HTMLElement)
+    }),
     async: PropTypes.bool
-  }
+  };
 
   state = {
     lineHeight: null
-  }
+  };
 
-  textarea: HTMLTextAreaElement | null
-  currentValue: TextareaAutosize.Props['value']
+  currentValue: TextareaAutosize.Props["value"];
 
   onResize = (e: Event): void => {
     if (this.props.onResize) {
       this.props.onResize(e);
     }
-  }
+  };
 
   componentDidMount() {
-    const { maxRows, async } = this.props;
+    const { maxRows, async, forwardedRef } = this.props;
 
-    if (typeof maxRows === 'number') {
+    if (typeof maxRows === "number") {
       this.updateLineHeight();
     }
 
-    if(typeof maxRows === "number" || async) {
+    if (typeof maxRows === "number" || async) {
       /*
         the defer is needed to:
           - force "autosize" to activate the scrollbar when this.props.maxRows is passed
           - support StyledComponents (see #71)
       */
-      setTimeout(() => this.textarea && autosize(this.textarea));
+      setTimeout(
+        () =>
+          forwardedRef && forwardedRef.current && autosize(forwardedRef.current)
+      );
     } else {
-      this.textarea && autosize(this.textarea)
+      forwardedRef && forwardedRef.current && autosize(forwardedRef.current);
     }
 
-    if (this.textarea) {
-      this.textarea.addEventListener(RESIZED, this.onResize);
+    if (forwardedRef && forwardedRef.current) {
+      forwardedRef.current.addEventListener(RESIZED, this.onResize);
     }
   }
 
   componentWillUnmount() {
-    if (this.textarea) {
-      this.textarea.removeEventListener(RESIZED, this.onResize);
-      autosize.destroy(this.textarea);
+    const { forwardedRef } = this.props;
+    if (forwardedRef && forwardedRef.current) {
+      forwardedRef.current.removeEventListener(RESIZED, this.onResize);
+      autosize.destroy(forwardedRef.current);
     }
   }
 
   updateLineHeight = () => {
-    if (this.textarea) {
+    const { forwardedRef } = this.props;
+    if (forwardedRef && forwardedRef.current) {
       this.setState({
-        lineHeight: getLineHeight(this.textarea)
+        lineHeight: getLineHeight(forwardedRef.current)
       });
     }
-  }
+  };
 
   onChange = (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
     const { onChange } = this.props;
     this.currentValue = e.currentTarget.value;
     onChange && onChange(e);
-  }
-
-  saveDOMNodeRef = (ref: HTMLTextAreaElement | null) => {
-    if (ref) {
-      const { innerRef } = this.props;
-
-      if (innerRef) {
-        innerRef(ref);
-      }
-
-      this.textarea = ref;
-    }
-  }
+  };
 
   getLocals = () => {
     const {
-      props: { onResize, maxRows, onChange, style, innerRef, ...props },
-      state: { lineHeight },
-      saveDOMNodeRef
+      props: { onResize, maxRows, onChange, style, ...props },
+      state: { lineHeight }
     } = this;
 
     const maxHeight = maxRows && lineHeight ? lineHeight * maxRows : null;
 
     return {
       ...props,
-      saveDOMNodeRef,
       style: maxHeight ? { ...style, maxHeight } : style,
       onChange: this.onChange
     };
-  }
+  };
 
   render() {
-    const { children, saveDOMNodeRef, ...locals } = this.getLocals();
+    const { children, forwardedRef, ...locals } = this.getLocals();
     return (
-      <textarea {...locals} ref={saveDOMNodeRef}>
+      <textarea {...locals} ref={forwardedRef}>
         {children}
       </textarea>
     );
   }
 
   componentDidUpdate() {
-    this.textarea && autosize.update(this.textarea);
+    const { forwardedRef } = this.props;
+    forwardedRef &&
+      forwardedRef.current &&
+      autosize.update(forwardedRef.current);
   }
-
 }
+
+export const TextareaAutosize = React.forwardRef(
+  (
+    props: TextareaAutosize.Props,
+    ref: React.RefObject<HTMLTextAreaElement>
+  ) => <TextareaAutosizeInner {...props} forwardedRef={ref} />
+);


### PR DESCRIPTION
Closes [#2522432](https://buildo.kaiten.io/space/[object Object]/card/2522432)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

I had a crack at this, unfortunately it's a breaking change for existing users of `innerRef`. I haven't used typescript much, just fudged my way through the types - hope it somewhat makes sense.

It's working for me with [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref): https://codesandbox.io/s/3vj061pv9p

See #102
