### PR TITLE
Update READMEs to make refs clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ ReactDOM.renderComponent(
 ```
 npm install --save react-autosize-textarea
 ```
+```
+yarn add react-autosize-textarea
+```
 
 ## Demo
 [Live Examples](http://react-components.buildo.io/#textareaautosize)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ In addition to them, `TextareaAutosize` comes with some optional custom `props` 
 | **rows** | <code>Number</code> |  | *optional*. Minimum number of visible rows |
 | **maxRows** | <code>Number</code> |  | *optional*. Maximum number of visible rows |
 | **async** | <code>Boolean</code> | <code>false</code> | *optional*. Initialize `autosize` asynchronously. Enable it if you are using StyledComponents. This is forced to true when `maxRows` is set. Async initialization will make your page "jump" when the component appears, as it will first be rendered with the normal size, then resized to content.
+| **ref** | <code>Function</code> |  | *optional*. Ref to the DOM node |
 
 
 #### `onResize`

--- a/src/README.md
+++ b/src/README.md
@@ -8,4 +8,4 @@ A light replacement for built-in `<textarea />` component which automatically ad
 | **onResize** | <code>Function</code> |  | *optional*. Called whenever the textarea resizes |
 | **rows** | <code>Number</code> |  | *optional*. Minimum number of visible rows |
 | **maxRows** | <code>Number</code> |  | *optional*. Maximum number of visible rows |
-| **innerRef** | <code>Function</code> |  | *optional*. Called with the ref to the DOM node |
+| **ref** | <code>Function</code> |  | *optional*. Called with the ref to the DOM node |


### PR DESCRIPTION
With the change from using `innerRef` to just using `ref`, I've opened this PR to make the docs a little clearer.