### PR TITLE
fix: loosen ref prop types

### DIFF
--- a/src/TextareaAutosize.tsx
+++ b/src/TextareaAutosize.tsx
@@ -57,7 +57,10 @@ class TextareaAutosizeClass extends React.Component<
     rows: PropTypes.number,
     maxRows: PropTypes.number,
     onResize: PropTypes.func,
-    innerRef: PropTypes.object,
+    innerRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
     async: PropTypes.bool
   };
 


### PR DESCRIPTION
Closes [#2520514](https://buildo.kaiten.io/space/32111/card/2520514)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

allow functions as ref type

closes: #141 